### PR TITLE
Make PCL an optional dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,37 +4,45 @@ cmake_minimum_required(VERSION 3.5)
 # produce the cmake var PROJECT_NAME
 project(point-cloud-read)
 
+# add option for PCL
+option(USE_PCL "Use PCL" OFF)
+if (USE_PCL)
+    add_definitions(-DPOINTCLOUDREAD_USES_PCL)
+endif()
+
 # set some names
 set(EXEC_TARGET_NAME "point-cloud-read")
 set(${EXEC_TARGET_NAME}_THRIFT src/idl.thrift)
 set(${EXEC_TARGET_NAME}_SRC src/main.cpp)
 
-# create a variable for the list of required YARP modules
-# this is needed since find_package(ICUBcontrib) overrides the YARP_LIBRARIES set by the first call to find_package(YARP)
-set(${EXEC_TARGET_NAME}_YARP_LIBRARIES)
+# find packages
+if (USE_PCL)
+    find_package(PCL REQUIRED)
+endif()
 
-# mandatory use of these packages
-find_package(YARP 3.0.101 REQUIRED COMPONENTS 
-                                            math 
-                                            OS 
-                                            sig
-                                            dev 
-                                            pcl 
-                                            idl_tools
+set (YARP_PCL_COMPONENT "")
+if (USE_PCL)
+    set (YARP_PCL_COMPONENT "pcl")
+endif()
+
+find_package(YARP 3.0.101 REQUIRED
+                          COMPONENTS
+                          OS
+                          math
+                          sig
+                          ${YARP_PCL_COMPONENT}
 )
-list(APPEND ${EXEC_TARGET_NAME}_YARP_LIBRARIES ${YARP_LIBRARIES})
 
 find_package(ICUBcontrib REQUIRED)
-list(APPEND ${EXEC_TARGET_NAME}_YARP_LIBRARIES ${YARP_LIBRARIES})
-list(REMOVE_DUPLICATES ${EXEC_TARGET_NAME}_YARP_LIBRARIES)
 
-# add PCL library
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
+if (USE_PCL)
+    include_directories(${PCL_INCLUDE_DIRS})
+    link_directories(${PCL_LIBRARY_DIRS})
+    add_definitions(${PCL_DEFINITIONS})
 
-# Fix some PCL bug related to Ubuntu
-list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
+    # Fix some PCL bug related to Ubuntu
+    list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
+endif()
 
 # extend the current search path used by cmake to load helpers
 list(APPEND CMAKE_MODULE_PATH ${ICUBCONTRIB_MODULE_PATH})
@@ -49,17 +57,23 @@ icubcontrib_set_default_prefix()
 # generate idl source and header
 yarp_add_idl(${EXEC_TARGET_NAME}_THRIFT_SRC ${${EXEC_TARGET_NAME}_THRIFT})
 
-# set the executable 
-add_executable(${EXEC_TARGET_NAME} 
+# set the executable
+add_executable(${EXEC_TARGET_NAME}
                                     ${${EXEC_TARGET_NAME}_SRC}
-                                    ${${EXEC_TARGET_NAME}_THRIFT} 
+                                    ${${EXEC_TARGET_NAME}_THRIFT}
                                     ${${EXEC_TARGET_NAME}_THRIFT_SRC}
 )
 
-target_link_libraries(${EXEC_TARGET_NAME} 
-                                            ${${EXEC_TARGET_NAME}_YARP_LIBRARIES}
-                                            ${PCL_LIBRARIES}
+target_link_libraries(${EXEC_TARGET_NAME}
+                      YARP::YARP_OS
+                      YARP::YARP_init
+                      YARP::YARP_sig
+                      YARP::YARP_math
 )
+
+if (USE_PCL)
+    target_link_libraries(${EXEC_TARGET_NAME} ${PCL_LIBRARIES} YARP::YARP_pcl)
+endif()
 
 # install the project executable
 install(TARGETS ${EXEC_TARGET_NAME} DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ endif()
 find_package(YARP 3.0.101 REQUIRED
                           COMPONENTS
                           OS
-                          math
                           sig
                           ${YARP_PCL_COMPONENT}
 )
@@ -68,7 +67,6 @@ target_link_libraries(${EXEC_TARGET_NAME}
                       YARP::YARP_OS
                       YARP::YARP_init
                       YARP::YARP_sig
-                      YARP::YARP_math
 )
 
 if (USE_PCL)

--- a/README.md
+++ b/README.md
@@ -6,20 +6,22 @@ Acquire point clouds of specific objects in the scene in order to save or stream
 - [Yarp](https://github.com/robotology/yarp)
 - [iCub](https://github.com/robotology/icub-main)
 - [IOL](https://github.com/robotology/iol)
-- PCL 1.7 (will be removed soon)
+
+#### Optional
+- [PCL](http://pointclouds.org/downloads/)
 
 ### Installation
 ```
 git clone https://github.com/fbottarel/point-cloud-read.git
 cd point-cloud-read
 mkdir build && cd build
-cmake ../
+cmake [-DUSE_PCL=ON] ../
 make install
 ```
 ### Usage
-The user might want to use this module when they want to acquire point clouds of objects currently in the scene in front of the robot. ` point-cloud-read` takes care of interfacing with the modules in [IOL](https://github.com/robotology/iol) to determine whether the queried object is in the scene, where it is, and retrieve the point cloud from the robot's stereo vision system. 
+The user might want to use this module when they want to acquire point clouds of objects currently in the scene in front of the robot. ` point-cloud-read` takes care of interfacing with the modules in [IOL](https://github.com/robotology/iol) to determine whether the queried object is in the scene, where it is, and retrieve the point cloud from the robot's stereo vision system.
 
-Once the module is running and connected (the code is comprehensive of a .xml application file for `yarpmanager`) it can be interacted with using the ports it opens: 
+Once the module is running and connected (the code is comprehensive of a .xml application file for `yarpmanager`) it can be interacted with using the ports it opens:
 - `/pointCloudRead/rpc` exposes an rpc interface to trigger acquisitions. See below for details
 - `/pointCloudRead/pointCloud:o` is a `yarp::os::BufferedPort` where the module publishes the acquired point clouds as `<yarp::sig::PointCloud<yarp::sig::DataXYZRGBA>>`
 
@@ -27,12 +29,8 @@ Typing `help` as rpc command returns a list of available commands, here briefly 
 - `set_period periodInSeconds` sets the streaming period to `periodInSeconds` seconds. Default `periodInSeconds` is 1.0
 - `stream_start objectName` starts the point cloud stream of an object recognized as `objectName` in the scene with period `periodInSeconds`. Empty point clouds are streamed if no `objectName` is found in the scene
 - `stream_stop` stops the point cloud stream
-- `stream_one objectName` triggers a one-shot acquisition and streaming. If no `objectName` is found in the scene, the command fails 
-- `dump_one objectName format` commands the module to acquire a point cloud and dump it to a file in the `.off` or `.pcd` format. The resulting file will be `objectName_point_cloud_XXX.[off|pcd]`, where `XXX` is a zero-filled number that increases when more point clouds of the same object are dumped. Such file is easily readable with programs such as MeshLab.
+- `stream_one objectName` triggers a one-shot acquisition and streaming. If no `objectName` is found in the scene, the command fails
+- `dump_one objectName format` commands the module to acquire a point cloud and dump it to a file in the `.off` or `.pcd` format. The resulting file will be
+  `objectName_point_cloud_XXX.[off|pcd]`, where `XXX` is a zero-filled number that increases when more point clouds of the same object are dumped. Such file
+  is easily readable with programs such as MeshLab. Note: the `.pcd` format is available only if the support to `PCL` is enabled.
 - `get_point_cloud objectName` returns a `yarp::os::Bottle` containing the point cloud of the required object as a `yarp::sig::PointCloud<yarp::sig::DataXYZRGBA>`.
-
-
-
-
-
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,10 @@
 #include <yarp/sig/all.h>
 #include <yarp/dev/all.h>
 #include <yarp/math/Math.h>
+
+#ifdef POINTCLOUDREAD_USES_PCL
 #include <yarp/pcl/Pcl.h>
+#endif
 
 #include <string>
 #include <iostream>
@@ -661,6 +664,7 @@ protected:
 
     }
 
+#ifdef POINTCLOUDREAD_USES_PCL
     int dumpToPCDFile(const string &filename, const PointCloud<DataXYZRGBA> &pointCloud)
     {
 
@@ -681,6 +685,7 @@ protected:
         return yarp::pcl::savePCD< yarp::sig::DataXYZRGBA, pcl::PointXYZRGBA>(filename_n_ext, pointCloud);
 
     }
+#endif
 
     bool dumpPointCloud(const string &format, const string &object){
 
@@ -704,6 +709,7 @@ protected:
                 else
                     yError() << "Dump failed!";
             }
+#ifdef POINTCLOUDREAD_USES_PCL
             else if (string_format_lowercase.compare("pcd") == 0)
             {
                 if (dumpToPCDFile(dumpFileName, yarpCloud) == 0)
@@ -715,6 +721,7 @@ protected:
                 else
                     yError() << "Dump failed!";
             }
+#endif
             else
                 yError() << "Invalid dump format.";
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,11 +7,16 @@
  *
  */
 
-
-#include <yarp/os/all.h>
-#include <yarp/sig/all.h>
-#include <yarp/dev/all.h>
-#include <yarp/math/Math.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/LockGuard.h>
+#include <yarp/os/Mutex.h>
+#include <yarp/os/ResourceFinder.h>
+#include <yarp/os/RFModule.h>
+#include <yarp/os/RpcClient.h>
+#include <yarp/os/RpcServer.h>
+#include <yarp/sig/Image.h>
+#include <yarp/sig/Matrix.h>
+#include <yarp/sig/PointCloud.h>
 
 #ifdef POINTCLOUDREAD_USES_PCL
 #include <yarp/pcl/Pcl.h>
@@ -30,7 +35,6 @@
 using namespace std;
 using namespace yarp::os;
 using namespace yarp::sig;
-using namespace yarp::math;
 
 /**************************************************************/
 


### PR DESCRIPTION
Since the `PCL` dependency isn't a trivial one and considering that the main task of the module can be accomplished without it, this PR makes `PCL` an optional dependency.

This closes #7 